### PR TITLE
Compress `<Trans>` with interpolated React components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.1.0
+
+**Features**
+
+- Support compressing `<Trans>` with interpolated variables & React components
+
 # 1.0.0
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -118,13 +118,10 @@ Available configuration options:
 
 ## Limitations
 
-1. If React components are interpolated inside of `<Trans>`, the key is not compressed. **Do not
-   supply a `i18nKey` manually, this will cause a runtime error.**
-
-2. If a key includes a namespace (like `ns:key`), the namespace will get lost during compression.
+1. If a key includes a namespace (like `ns:key`), the namespace will get lost during compression.
    **This will cause a runtime error.** If you need this functionality, feel free to submit a PR!
 
-3. Calling `t` with a variable argument is not supported, use a string literal instead. This will
+2. Calling `t` with a variable argument is not supported, use a string literal instead. This will
    throw an error during build.
 
 ```diff
@@ -132,7 +129,7 @@ Available configuration options:
 + t('string literal')
 ```
 
-4. Calling `<Trans>` with a variable `i18nKey` attribute is not supported, use a string literal
+3. Calling `<Trans>` with a variable `i18nKey` attribute is not supported, use a string literal
    instead. This will throw an error during build.
 
 ```diff
@@ -140,7 +137,7 @@ Available configuration options:
 + <Trans i18nKey='string literal'>
 ```
 
-5. Calling `<Trans>` with spread attributes is not supported, use explicit attributes instead. This
+4. Calling `<Trans>` with spread attributes is not supported, use explicit attributes instead. This
    will throw an error during build.
 
 ```diff
@@ -150,7 +147,7 @@ Available configuration options:
 
 ## Troubleshooting
 
-**My text shows up as a hash like `1b7396`.**
+**My text shows up as a hash like `1b7396` or characters like `~~~`.**
 
 This means that the translation for the uncompressed key is missing from your locale files. It is
 recommended to use tools like [i18next-parser](https://github.com/i18next/i18next-parser) and

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -145,11 +145,34 @@ function unsupportedCodeUse(message: string) {
 export function childrenToKey(children: BabelTypes.JSXElement['children']): string {
   let key = ''
 
-  for (const child of children) {
+  for (let i = 0; i !== children.length; i++) {
+    const child = children[i]
+
+    if (child.type === 'JSXElement') {
+      key += `<${i}>` + childrenToKey(child.children) + `</${i}>`
+      continue
+    }
+
     if (child.type === 'JSXText') {
       key += child.value
+      continue
     }
+
+    if (child.type === 'JSXExpressionContainer') {
+      // Ignore, used for comments like `{/* this */}`
+      continue
+    }
+
+    if (child.type === 'JSXSpreadChild') {
+      unsupportedCodeUse('`<Trans>{...variable}</Trans>` is not supported (by NextJS)')
+    }
+
+    if (child.type === 'JSXFragment') {
+      unsupportedCodeUse('`<Trans>Text <>here</></Trans>` is not supported')
+    }
+
+    throw new Error('[next-i18next-compress] Unknown AST type: ' + child.type)
   }
 
-  return key
+  return key.trim()
 }

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -124,8 +124,13 @@ export default function nextI18nextCompressBabelPlugin(
         )
         path.node.openingElement.attributes.push(keyAttribute as any) // eslint-disable-line @typescript-eslint/no-explicit-any
 
-        if (path.node.children.length === 1 && path.node.children[0].type === 'JSXText') {
-          // If there is only one text child, strip it out and remove the closing element.
+        const canTurnIntoSelfClosing =
+          path.node.children.length === 0 ||
+          (path.node.children.length === 1 && path.node.children[0].type === 'JSXText')
+
+        if (canTurnIntoSelfClosing) {
+          // If there is no children or only one text child, turn it into a self-closing element
+          // with no children or additional closing element.
           // `<Trans>Foo</Trans>` -> `<Trans i18nKey={...} />`
           path.node.children = []
           delete path.node.closingElement

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -104,14 +104,14 @@ export default function nextI18nextCompressBabelPlugin(
           i18nKeyAttributeValue = i18nKeyAttribute.value.value
         }
 
-        // Get the value of the child text node, if it exists
-        let childTextNodeValue
-        if (path.node.children[0] && path.node.children[0].type === 'JSXText') {
-          childTextNodeValue = path.node.children[0].value
+        // Get the key based on the children, if they exist
+        let childrenValue
+        if (path.node.children.length > 0) {
+          childrenValue = childrenToKey(path.node.children as BabelTypes.JSXElement['children'])
         }
 
         // The key is either the `i18nKey` attribute or the child text node
-        const key = (i18nKeyAttributeValue || childTextNodeValue) as string
+        const key = (i18nKeyAttributeValue || childrenValue) as string
 
         // Generate the new `i18nKey` attribute with the compressed key
         const keyAttribute = {
@@ -140,4 +140,16 @@ export default function nextI18nextCompressBabelPlugin(
 
 function unsupportedCodeUse(message: string) {
   throw new Error('[next-i18next-compress] Unsupported code use: ' + message)
+}
+
+export function childrenToKey(children: BabelTypes.JSXElement['children']): string {
+  let key = ''
+
+  for (const child of children) {
+    if (child.type === 'JSXText') {
+      key += child.value
+    }
+  }
+
+  return key
 }

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -7,7 +7,7 @@ import { mergeDefaultOptions, Options } from './options'
 // which would cause us to compress the key twice.
 const processedNodes = new Set()
 
-interface Babel {
+export interface Babel {
   types: typeof BabelTypes
 }
 

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -74,7 +74,7 @@ export default function nextI18nextCompressBabelPlugin(
         // istanbul ignore next
         if (processedNodes.has(path.node)) return
 
-        // Only handle JSX elements with the name `Trans` and either one text child or no children
+        // Only handle JSX elements with the name `Trans`
         if (!t.isJSXIdentifier(path.node.openingElement.name, { name: 'Trans' })) return
 
         // We don't support cases where a variable is spread into the attributes,
@@ -103,13 +103,13 @@ export default function nextI18nextCompressBabelPlugin(
         }
 
         // Get the key based on the children, if they exist
-        let childrenValue
+        let childrenKey
         if (path.node.children.length > 0) {
-          childrenValue = childrenToKey(path.node.children as BabelTypes.JSXElement['children'])
+          childrenKey = childrenToKey(path.node.children as BabelTypes.JSXElement['children'])
         }
 
         // The key is either the `i18nKey` attribute or the child text node
-        const key = (i18nKeyAttributeValue || childrenValue) as string
+        const key = (i18nKeyAttributeValue || childrenKey) as string
 
         // Generate the new `i18nKey` attribute with the compressed key
         const keyAttribute = {
@@ -170,7 +170,7 @@ export function childrenToKey(children: BabelTypes.JSXElement['children']): stri
       // Ignore trailing newlines
       text = text.replace(/\n *$/g, '')
 
-      // Turn leading newlines into spaces
+      // Turn remaining newlines into spaces
       text = text.replace(/\n */g, ' ')
 
       // Trim the start if we are the first child
@@ -188,13 +188,13 @@ export function childrenToKey(children: BabelTypes.JSXElement['children']): stri
     }
 
     if (child.type === 'JSXExpressionContainer') {
-      // Take expressions like `{'  '}` exactly as they are
+      // Take the value of string literal expressions like `{'  '}` as-is
       if (child.expression.type === 'StringLiteral') {
         key += child.expression.value
         continue
       }
 
-      // Handle interpolated variables by name
+      // Add markers for interpolated variables by name
       if (child.expression.type === 'Identifier') {
         key += `{${child.expression.name}}`
         continue

--- a/src/babel.ts
+++ b/src/babel.ts
@@ -154,12 +154,16 @@ export function childrenToKey(children: BabelTypes.JSXElement['children']): stri
     }
 
     if (child.type === 'JSXText') {
-      key += child.value
+      key += child.value.trim().replace(/\n */g, ' ')
       continue
     }
 
     if (child.type === 'JSXExpressionContainer') {
-      // Ignore, used for comments like `{/* this */}`
+      if (child.expression.type === 'StringLiteral') {
+        key += child.expression.value
+      }
+
+      // Ignore other expressions, usually used for comments like `{/* this */}`
       continue
     }
 
@@ -174,5 +178,5 @@ export function childrenToKey(children: BabelTypes.JSXElement['children']): stri
     throw new Error('[next-i18next-compress] Unknown AST type: ' + child.type)
   }
 
-  return key.trim()
+  return key
 }

--- a/src/compressKey.ts
+++ b/src/compressKey.ts
@@ -1,14 +1,8 @@
 import crypto from 'crypto'
 
+// Hash the key's content into 6 characters. A collision may occur with a sufficiently
+// large locale file. Using 6 characters and a locale file with 100 keys, the probability of a
+// collision is about 0.029%.
 export function compressKey(string: string, hashLength: number) {
-  // Don't compress keys with interpolated React components
-  if (string.match(/<.*?>/g)) return string
-
-  // Strip whitespace to make keys extracted from Babel consistent with keys in locale files
-  string = string.trim().replace(/( |\n)+/g, ' ')
-
-  // Hash the key's content into 6 characters. A collision may occur with a sufficiently
-  // large locale file. Using 6 characters and a locale file with 100 keys, the probability of a
-  // collision is about 0.029%.
   return crypto.createHash('sha256').update(string).digest('hex').slice(0, hashLength)
 }

--- a/tests/__snapshots__/babel.spec.ts.snap
+++ b/tests/__snapshots__/babel.spec.ts.snap
@@ -58,6 +58,18 @@ exports[`babel \`<Trans>\` component correctly compresses components with interp
 }"
 `;
 
+exports[`babel \`<Trans>\` component correctly compresses components with interpolated React components (5) 1`] = `
+"export function ReactComponent() {
+  const {
+    t
+  } = useTranslation('namespace');
+  return <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t} i18nKey=\\"bb42f8\\" />
+              <Trans t={t} i18nKey=\\"bb42f8\\" />
+            </Headline>;
+}"
+`;
+
 exports[`babel \`<Trans>\` component correctly compresses components with interpolated variable 1`] = `
 "export function ReactComponent() {
   const {

--- a/tests/__snapshots__/babel.spec.ts.snap
+++ b/tests/__snapshots__/babel.spec.ts.snap
@@ -11,6 +11,53 @@ exports[`babel \`<Trans>\` component can configure the length of the compressed 
 }"
 `;
 
+exports[`babel \`<Trans>\` component correctly compresses components with interpolated React components (1) 1`] = `
+"export function ReactComponent() {
+  const {
+    t
+  } = useTranslation('namespace');
+  return <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t} i18nKey=\\"1f04cd\\"><Link>~</Link></Trans>
+            </Headline>;
+}"
+`;
+
+exports[`babel \`<Trans>\` component correctly compresses components with interpolated React components (2) 1`] = `
+"export function ReactComponent() {
+  const {
+    t
+  } = useTranslation('namespace');
+  return <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t} i18nKey=\\"bf56a7\\">~<Link>~</Link>
+              </Trans>
+            </Headline>;
+}"
+`;
+
+exports[`babel \`<Trans>\` component correctly compresses components with interpolated React components (3) 1`] = `
+"export function ReactComponent() {
+  const {
+    t
+  } = useTranslation('namespace');
+  return <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t} i18nKey=\\"4f9d22\\">
+                <Link />~</Trans>
+            </Headline>;
+}"
+`;
+
+exports[`babel \`<Trans>\` component correctly compresses components with interpolated React components (4) 1`] = `
+"export function ReactComponent() {
+  const {
+    t
+  } = useTranslation('namespace');
+  return <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t} i18nKey=\\"bb42f8\\">~<Link>~</Link>
+              </Trans>
+            </Headline>;
+}"
+`;
+
 exports[`babel \`<Trans>\` component correctly compresses the child text node as the key 1`] = `
 "export function ReactComponent() {
   const {
@@ -47,56 +94,6 @@ exports[`babel \`<Trans>\` component correctly compresses the i18nKey attribute 
 exports[`babel \`<Trans>\` component errors for components with variable i18nKey attribute 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans i18nKey={variable}>\` is not supported, use a string literal instead."`;
 
 exports[`babel \`<Trans>\` component errors for components with variable spreads 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans {...variable}>\` is not supported, use explicit attributes instead."`;
-
-exports[`babel \`<Trans>\` component ignores components with interpolated React components (1) 1`] = `
-"export function ReactComponent() {
-  const {
-    t
-  } = useTranslation('namespace');
-  return <Headline as='h1' size='xl' textAlign='center'>
-              <Trans t={t}><Link>Forgot password</Link></Trans>
-            </Headline>;
-}"
-`;
-
-exports[`babel \`<Trans>\` component ignores components with interpolated React components (2) 1`] = `
-"export function ReactComponent() {
-  const {
-    t
-  } = useTranslation('namespace');
-  return <Headline as='h1' size='xl' textAlign='center'>
-              <Trans t={t}>
-                Forgot <Link>password</Link>
-              </Trans>
-            </Headline>;
-}"
-`;
-
-exports[`babel \`<Trans>\` component ignores components with interpolated React components (3) 1`] = `
-"export function ReactComponent() {
-  const {
-    t
-  } = useTranslation('namespace');
-  return <Headline as='h1' size='xl' textAlign='center'>
-              <Trans t={t}>
-                <Link /> Forgot password
-              </Trans>
-            </Headline>;
-}"
-`;
-
-exports[`babel \`<Trans>\` component ignores components with interpolated React components (4) 1`] = `
-"export function ReactComponent() {
-  const {
-    t
-  } = useTranslation('namespace');
-  return <Headline as='h1' size='xl' textAlign='center'>
-              <Trans t={t} i18nKey='Forgot password'>
-                Forgot <Link>password</Link>
-              </Trans>
-            </Headline>;
-}"
-`;
 
 exports[`babel \`t\` function can configure the length of the compressed key 1`] = `
 "export function ReactComponent() {

--- a/tests/__snapshots__/babel.spec.ts.snap
+++ b/tests/__snapshots__/babel.spec.ts.snap
@@ -127,6 +127,12 @@ exports[`babel \`t\` function ignores function calls with no arguments 1`] = `
 }"
 `;
 
+exports[`babel childrenToKey errors on fragment 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans>Text <>here</></Trans>\` is not supported"`;
+
+exports[`babel childrenToKey errors on interpolated expression 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans>Text {function()}</Trans>\` is not supported"`;
+
+exports[`babel childrenToKey errors on spread children 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans>{...variable}</Trans>\` is not supported (by NextJS)"`;
+
 exports[`babel does nothing if running in development 1`] = `
 "export function ReactComponent() {
   const {

--- a/tests/__snapshots__/babel.spec.ts.snap
+++ b/tests/__snapshots__/babel.spec.ts.snap
@@ -58,6 +58,18 @@ exports[`babel \`<Trans>\` component correctly compresses components with interp
 }"
 `;
 
+exports[`babel \`<Trans>\` component correctly compresses components with interpolated variable 1`] = `
+"export function ReactComponent() {
+  const {
+    t
+  } = useTranslation('namespace');
+  const name = 'Sam';
+  return <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t} i18nKey=\\"371405\\">~{name}~</Trans>
+            </Headline>;
+}"
+`;
+
 exports[`babel \`<Trans>\` component correctly compresses the child text node as the key 1`] = `
 "export function ReactComponent() {
   const {

--- a/tests/__snapshots__/babel.spec.ts.snap
+++ b/tests/__snapshots__/babel.spec.ts.snap
@@ -130,6 +130,8 @@ exports[`babel childrenToKey errors on interpolated expression 1`] = `"unknown: 
 
 exports[`babel childrenToKey errors on spread children 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans>{...variable}</Trans>\` is not supported (by NextJS)"`;
 
+exports[`babel childrenToKey errors on unknown AST type 1`] = `"[next-i18next-compress] Unknown AST type: Foobar"`;
+
 exports[`babel does nothing if running in development 1`] = `
 "export function ReactComponent() {
   const {

--- a/tests/__snapshots__/babel.spec.ts.snap
+++ b/tests/__snapshots__/babel.spec.ts.snap
@@ -129,7 +129,7 @@ exports[`babel \`t\` function ignores function calls with no arguments 1`] = `
 
 exports[`babel childrenToKey errors on fragment 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans>Text <>here</></Trans>\` is not supported"`;
 
-exports[`babel childrenToKey errors on interpolated expression 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans>Text {function()}</Trans>\` is not supported"`;
+exports[`babel childrenToKey errors on interpolated expression 1`] = `"unknown: [next-i18next-compress] Unknown AST type: CallExpression"`;
 
 exports[`babel childrenToKey errors on spread children 1`] = `"unknown: [next-i18next-compress] Unsupported code use: \`<Trans>{...variable}</Trans>\` is not supported (by NextJS)"`;
 

--- a/tests/__snapshots__/babel.spec.ts.snap
+++ b/tests/__snapshots__/babel.spec.ts.snap
@@ -78,6 +78,19 @@ exports[`babel \`<Trans>\` component ignores components with interpolated React 
     t
   } = useTranslation('namespace');
   return <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t}>
+                <Link /> Forgot password
+              </Trans>
+            </Headline>;
+}"
+`;
+
+exports[`babel \`<Trans>\` component ignores components with interpolated React components (4) 1`] = `
+"export function ReactComponent() {
+  const {
+    t
+  } = useTranslation('namespace');
+  return <Headline as='h1' size='xl' textAlign='center'>
               <Trans t={t} i18nKey='Forgot password'>
                 Forgot <Link>password</Link>
               </Trans>

--- a/tests/__snapshots__/parseLocaleFile.spec.ts.snap
+++ b/tests/__snapshots__/parseLocaleFile.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`parseLocaleFile can configure the length of the compressed key 1`] = `
 Object {
-  "Or <1>start your 30-day free trial</1>": "Oder <1>beginne deine 30-Tage kostenlose Probephase</1>",
+  "0d1f217dd077602b": "Oder <1>beginne deine 30-Tage kostenlose Probephase</1>",
   "bb42f8cd525dba08": "Passwort vergessen",
   "d9055ff096c25633": "Deine Anmeldedaten waren inkorrekt.",
   "f2488fd4ef4adbc6": "E-Mail Adresse",
@@ -11,7 +11,7 @@ Object {
 
 exports[`parseLocaleFile correctly compresses the keys of the locale file 1`] = `
 Object {
-  "Or <1>start your 30-day free trial</1>": "Oder <1>beginne deine 30-Tage kostenlose Probephase</1>",
+  "0d1f21": "Oder <1>beginne deine 30-Tage kostenlose Probephase</1>",
   "bb42f8": "Passwort vergessen",
   "d9055f": "Deine Anmeldedaten waren inkorrekt.",
   "f2488f": "E-Mail Adresse",

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -360,6 +360,12 @@ describe('babel', () => {
         `)
       ).toThrowErrorMatchingSnapshot()
     })
+
+    it('errors on unknown AST type', () => {
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore Forcing an invalid AST type
+      expect(() => childrenToKey([{ type: 'Foobar' }])).toThrowErrorMatchingSnapshot()
+    })
   })
 
   it('does nothing if the file is in node_modules', () => {

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -127,7 +127,7 @@ describe('babel', () => {
       expect(transform(input, { hashLength: 16 })).toMatchSnapshot()
     })
 
-    it('ignores components with interpolated React components (1)', () => {
+    it('correctly compresses components with interpolated React components (1)', () => {
       const input = `
         export function ReactComponent() {
           const { t } = useTranslation('namespace')
@@ -142,7 +142,7 @@ describe('babel', () => {
       expect(transform(input)).toMatchSnapshot()
     })
 
-    it('ignores components with interpolated React components (2)', () => {
+    it('correctly compresses components with interpolated React components (2)', () => {
       const input = `
         export function ReactComponent() {
           const { t } = useTranslation('namespace')
@@ -159,7 +159,7 @@ describe('babel', () => {
       expect(transform(input)).toMatchSnapshot()
     })
 
-    it('ignores components with interpolated React components (3)', () => {
+    it('correctly compresses components with interpolated React components (3)', () => {
       const input = `
         export function ReactComponent() {
           const { t } = useTranslation('namespace')
@@ -176,7 +176,7 @@ describe('babel', () => {
       expect(transform(input)).toMatchSnapshot()
     })
 
-    it('ignores components with interpolated React components (4)', () => {
+    it('correctly compresses components with interpolated React components (4)', () => {
       // TODO This is a bug right now, the i18nKey in the local file will get compressed,
       //      but the i18nKey in the JavaScript bundle is ignored. Fix this when we support
       //      compressing interpolated components!

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -193,6 +193,24 @@ describe('babel', () => {
       expect(transform(input)).toMatchSnapshot()
     })
 
+    it('correctly compresses components with interpolated variable', () => {
+      const input = `
+        export function ReactComponent() {
+          const { t } = useTranslation('namespace')
+          const name = 'Sam'
+          return (
+            <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t}>
+                Happy birthday, {name}!
+              </Trans>
+            </Headline>
+          )
+        }
+      `
+
+      expect(transform(input)).toMatchSnapshot()
+    })
+
     it('errors for components with variable spreads', () => {
       const input = `
         export function ReactComponent() {

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -3,8 +3,9 @@ import { transformSync } from '@babel/core'
 // @ts-ignore Import JSX syntax support plugin
 import jsxSyntaxPlugin from '@babel/plugin-syntax-jsx'
 import { TransformOptions } from '@babel/core'
-import babelPlugin from '../src/babel'
+import babelPlugin, { childrenToKey } from '../src/babel'
 import { Options } from '../src/options'
+import { JSXElement } from '@babel/types'
 
 function transform(input: string, options?: Partial<Options>, babelOptions?: TransformOptions) {
   const output = transformSync(input, {
@@ -209,6 +210,14 @@ describe('babel', () => {
       `
 
       expect(() => transform(input)).toThrowErrorMatchingSnapshot()
+    })
+  })
+
+  describe('childrenToKey', () => {
+    it('generates a key out of a text node', () => {
+      const children = [{ type: 'JSXText', value: 'Foobar' }] as JSXElement['children']
+
+      expect(childrenToKey(children)).toEqual('Foobar')
     })
   })
 

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -193,6 +193,22 @@ describe('babel', () => {
       expect(transform(input)).toMatchSnapshot()
     })
 
+    it('correctly compresses components with interpolated React components (5)', () => {
+      const input = `
+        export function ReactComponent() {
+          const { t } = useTranslation('namespace')
+          return (
+            <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t} i18nKey='Forgot password' />
+              <Trans t={t} i18nKey='Forgot password'></Trans>
+            </Headline>
+          )
+        }
+      `
+
+      expect(transform(input)).toMatchSnapshot()
+    })
+
     it('correctly compresses components with interpolated variable', () => {
       const input = `
         export function ReactComponent() {

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -177,10 +177,6 @@ describe('babel', () => {
     })
 
     it('correctly compresses components with interpolated React components (4)', () => {
-      // TODO This is a bug right now, the i18nKey in the local file will get compressed,
-      //      but the i18nKey in the JavaScript bundle is ignored. Fix this when we support
-      //      compressing interpolated components!
-
       const input = `
         export function ReactComponent() {
           const { t } = useTranslation('namespace')

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -160,6 +160,23 @@ describe('babel', () => {
     })
 
     it('ignores components with interpolated React components (3)', () => {
+      const input = `
+        export function ReactComponent() {
+          const { t } = useTranslation('namespace')
+          return (
+            <Headline as='h1' size='xl' textAlign='center'>
+              <Trans t={t}>
+                <Link/> Forgot password
+              </Trans>
+            </Headline>
+          )
+        }
+      `
+
+      expect(transform(input)).toMatchSnapshot()
+    })
+
+    it('ignores components with interpolated React components (4)', () => {
       // TODO This is a bug right now, the i18nKey in the local file will get compressed,
       //      but the i18nKey in the JavaScript bundle is ignored. Fix this when we support
       //      compressing interpolated components!

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -274,6 +274,27 @@ describe('babel', () => {
 
       expect(key).toEqual('Sign in to your account')
     })
+
+    it('generates a key out of basic text and explicit whitespace', () => {
+      const key = childrenToKeyFromJSX(`
+        <Trans t={t}>
+          Sign in to{'  '}your account{' '}
+        </Trans>
+      `)
+
+      expect(key).toEqual('Sign in to  your account ')
+    })
+
+    it('generates a key out of basic text with stripped whitespace', () => {
+      const key = childrenToKeyFromJSX(`
+        <Trans t={t}>
+          Lorem ipsum dolor sit amet,
+          consectetur adipiscing elit.
+        </Trans>
+      `)
+
+      expect(key).toEqual('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+    })
   })
 
   it('does nothing if the file is in node_modules', () => {

--- a/tests/babel.spec.ts
+++ b/tests/babel.spec.ts
@@ -254,7 +254,7 @@ describe('babel', () => {
       return key
     }
 
-    it('generates a key out of basic text', () => {
+    it('handles basic text', () => {
       const key = childrenToKeyFromJSX(`
         <Trans t={t}>
           Sign in to your account
@@ -264,7 +264,7 @@ describe('babel', () => {
       expect(key).toEqual('Sign in to your account')
     })
 
-    it('generates a key out of basic text and a comment', () => {
+    it('handles basic text and a comment', () => {
       const key = childrenToKeyFromJSX(`
         <Trans t={t}>
           Sign in to your account
@@ -275,7 +275,7 @@ describe('babel', () => {
       expect(key).toEqual('Sign in to your account')
     })
 
-    it('generates a key out of basic text and explicit whitespace', () => {
+    it('handles basic text and explicit whitespace', () => {
       const key = childrenToKeyFromJSX(`
         <Trans t={t}>
           Sign in to{'  '}your account{' '}
@@ -285,7 +285,7 @@ describe('babel', () => {
       expect(key).toEqual('Sign in to  your account ')
     })
 
-    it('generates a key out of basic text with stripped whitespace', () => {
+    it('handles basic text and stripped whitespace', () => {
       const key = childrenToKeyFromJSX(`
         <Trans t={t}>
           Lorem ipsum dolor sit amet,
@@ -294,6 +294,71 @@ describe('babel', () => {
       `)
 
       expect(key).toEqual('Lorem ipsum dolor sit amet, consectetur adipiscing elit.')
+    })
+
+    it('handles interpolated component', () => {
+      const key = childrenToKeyFromJSX(`
+        <Trans t={t}>
+          Or <NextLink href='/register'>start your 30-day free trial</NextLink>
+        </Trans>
+      `)
+
+      expect(key).toEqual('Or <1>start your 30-day free trial</1>')
+    })
+
+    it('handles multiple interpolated components', () => {
+      const key = childrenToKeyFromJSX(`
+        <Trans t={t}>
+          You have read and acknowledge the{' '}
+          <Link>Terms of Service</Link> and <Link>Privacy Notice</Link>.
+        </Trans>
+      `)
+
+      expect(key).toEqual(
+        'You have read and acknowledge the <2>Terms of Service</2> and <4>Privacy Notice</4>.'
+      )
+    })
+
+    it('handles self-closing interpolated component', () => {
+      const key = childrenToKeyFromJSX(`
+        <Trans t={t}>
+          <Iceberg /> There's something in the water.
+        </Trans>
+      `)
+
+      expect(key).toEqual("<0></0> There's something in the water.")
+    })
+
+    it('handles interpolated variable', () => {
+      const key = childrenToKeyFromJSX(`
+        <Trans t={t}>Welcome to {name}'s birthday party!</Trans>
+      `)
+
+      expect(key).toEqual("Welcome to {name}'s birthday party!")
+    })
+
+    it('errors on interpolated expression', () => {
+      expect(() =>
+        childrenToKeyFromJSX(`
+          <Trans t={t}>They do travel in herds: {array.join(', ')}</Trans>
+        `)
+      ).toThrowErrorMatchingSnapshot()
+    })
+
+    it('errors on spread children', () => {
+      expect(() =>
+        childrenToKeyFromJSX(`
+          <Trans>Foo {...variable} bar</Trans>
+        `)
+      ).toThrowErrorMatchingSnapshot()
+    })
+
+    it('errors on fragment', () => {
+      expect(() =>
+        childrenToKeyFromJSX(`
+          <Trans>Foo <>bar</></Trans>
+        `)
+      ).toThrowErrorMatchingSnapshot()
     })
   })
 

--- a/tests/compressKey.spec.ts
+++ b/tests/compressKey.spec.ts
@@ -3,13 +3,6 @@ import { compressKey } from '../src/compressKey'
 describe('compressKey', () => {
   it('compresses the key', () => {
     expect(compressKey('Email address', 6)).toEqual('f2488f')
-  })
-
-  it('compresses the key without whitespace', () => {
-    expect(compressKey('Email  \naddress', 6)).toEqual('f2488f')
-  })
-
-  it('ignores keys with interpolated React components', () => {
-    expect(compressKey('Sign up <1>here</1>', 6)).toEqual('Sign up <1>here</1>')
+    expect(compressKey('Sign up <1>here</1>', 6)).toEqual('6e4c86')
   })
 })


### PR DESCRIPTION
Closes #2

- [x] Update the spreadsheet and see how much we save in total now

---

Savings (no compression vs full compression with 6 characters):

|              | Before   | After    | Total Savings | Locale Size | % Locale Savings |
|--------------|----------|----------|---------------|-------------|------------------|
| /en/sign-in  | 216.04kb | 215.54kb | -0.50kb       | 1.08kb      | 45.84%           |
| /de/sign-in  | 216.85kb | 215.71kb | -1.14kb       | 1.83kb      | 62.08%           |
| /en/register | 215.54kb | 215.05kb | -0.49kb       | 1.12kb      | 43.74%           |
| /de/register | 216.37kb | 215.23kb | -1.15kb       | 1.90kb      | 60.30%           |